### PR TITLE
Apples spawn in their correct locations

### DIFF
--- a/src/entities/apple.rs
+++ b/src/entities/apple.rs
@@ -11,9 +11,9 @@ pub struct Apple {
 
 impl Apple {
     pub fn new() -> Self {
-        let x_coordinate = rand::thread_rng().gen_range(0.0..PIXEL_SIZE) as f32 * BOARD_SIZE;
+        let x_coordinate = rand::thread_rng().gen_range(0..PIXEL_SIZE as i32) as f32 * BOARD_SIZE;
         let y_coordinate =
-            rand::thread_rng().gen_range((-PIXEL_SIZE + 1.)..=0.) as f32 * BOARD_SIZE;
+            rand::thread_rng().gen_range((-PIXEL_SIZE as i32+ 1)..=0) as f32 * BOARD_SIZE;
 
         Apple {
             a: SpriteBundle {


### PR DESCRIPTION
Stopped the random number generation from creating floating point values.

Closes #1 